### PR TITLE
Collect all types from all specified assemblies before doing registrations

### DIFF
--- a/AutomaticTypeMapper.Test/AutomaticTypeMapper.Test.csproj
+++ b/AutomaticTypeMapper.Test/AutomaticTypeMapper.Test.csproj
@@ -49,6 +49,12 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="Unity.Abstractions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.5.9.7\lib\net46\Unity.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Container, Version=5.9.7.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unity.5.9.7\lib\net46\Unity.Container.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RegisterAutoMappedTypesTest.cs" />
@@ -61,7 +67,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutomaticTypeMapper\AutomaticTypeMapper.csproj">
@@ -75,6 +83,10 @@
     <ProjectReference Include="..\InvalidTypes\InvalidTypes.csproj">
       <Project>{4f519896-6520-493f-ad14-b0c898fd696a}</Project>
       <Name>InvalidTypes</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\WorkingAssembly\WorkingAssembly.csproj">
+      <Project>{4f519896-6520-493f-ad14-b0c898fd696b}</Project>
+      <Name>WorkingAssembly</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/AutomaticTypeMapper.Test/RegisterDiscoveredTypesTest.cs
+++ b/AutomaticTypeMapper.Test/RegisterDiscoveredTypesTest.cs
@@ -1,8 +1,8 @@
 ﻿using AutomaticTypeMapper.Test.Types;
-using InvalidTypes;
 using NUnit.Framework;
 using System.Linq;
 using System.Reflection;
+using WorkingAssembly;
 
 namespace AutomaticTypeMapper.Test
 {
@@ -225,6 +225,24 @@ namespace AutomaticTypeMapper.Test
                 var registry = new UnityRegistry(assemblyName);
 
                 Assert.That(registry.RegisterDiscoveredTypes, Throws.InvalidOperationException);
+            }
+
+            [Test]
+            public void TaggedClass_WithVariedInterface_AcrossAssemblies_GetsRegisteredAsVaried()
+            {
+                var assemblyName = Assembly.GetExecutingAssembly().FullName;
+                using (var registry = new UnityRegistry(assemblyName, "WorkingAssembly"))
+                {
+                    registry.RegisterDiscoveredTypes();
+
+                    var instance = registry.Resolve<NotAcrossAssembly>();
+                    var instances = registry.ResolveAll<UsedAcrossAssemblies>().ToList();
+
+                    Assert.That(instance, Is.Not.Null);
+                    Assert.That(instances, Has.Count.EqualTo(2));
+                    Assert.That(instances, Has.One.TypeOf<UsedAcrossAssembliesImpl1>());
+                    Assert.That(instances, Has.One.TypeOf<UsedAcrossAssembliesImpl2>());
+                }
             }
 
             [TearDown]

--- a/AutomaticTypeMapper.Test/Types/MultipleAttributes.cs
+++ b/AutomaticTypeMapper.Test/Types/MultipleAttributes.cs
@@ -1,4 +1,6 @@
-﻿namespace AutomaticTypeMapper.Test.Types
+﻿using WorkingAssembly;
+
+namespace AutomaticTypeMapper.Test.Types
 {
     public interface BaseInterface1 { }
     public interface BaseInterface2 { }
@@ -13,4 +15,10 @@
     [MappedType(BaseType = typeof(BaseInterfaceSingleton1), IsSingleton = true)]
     [MappedType(BaseType = typeof(BaseInterfaceSingleton2), IsSingleton = true)]
     public class MultipleAttributesSingleton : BaseInterfaceSingleton1, BaseInterfaceSingleton2 { }
+
+    public interface NotAcrossAssembly { }
+
+    [MappedType(BaseType = typeof(NotAcrossAssembly))]
+    [MappedType(BaseType = typeof(UsedAcrossAssemblies))]
+    public class UsedAcrossAssembliesImpl2 : UsedAcrossAssemblies, NotAcrossAssembly { }
 }

--- a/AutomaticTypeMapper.Test/packages.config
+++ b/AutomaticTypeMapper.Test/packages.config
@@ -3,4 +3,5 @@
   <package id="NUnit" version="3.11.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net462" />
+  <package id="Unity" version="5.9.7" targetFramework="net462" />
 </packages>

--- a/AutomaticTypeMapper.sln
+++ b/AutomaticTypeMapper.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvalidTypes", "InvalidType
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvalidAutoTypes", "InvalidAutoTypes\InvalidAutoTypes.csproj", "{ADFD900D-6563-4754-85C9-CA947EE19735}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkingAssembly", "WorkingAssembly\WorkingAssembly.csproj", "{41D2E11E-35B4-42A0-B661-DCC74369B86D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -33,6 +35,10 @@ Global
 		{ADFD900D-6563-4754-85C9-CA947EE19735}.Debug|x86.Build.0 = Debug|x86
 		{ADFD900D-6563-4754-85C9-CA947EE19735}.Release|x86.ActiveCfg = Release|x86
 		{ADFD900D-6563-4754-85C9-CA947EE19735}.Release|x86.Build.0 = Release|x86
+		{41D2E11E-35B4-42A0-B661-DCC74369B86D}.Debug|x86.ActiveCfg = Debug|x86
+		{41D2E11E-35B4-42A0-B661-DCC74369B86D}.Debug|x86.Build.0 = Debug|x86
+		{41D2E11E-35B4-42A0-B661-DCC74369B86D}.Release|x86.ActiveCfg = Release|x86
+		{41D2E11E-35B4-42A0-B661-DCC74369B86D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WorkingAssembly/MultipleSameAttribute.cs
+++ b/WorkingAssembly/MultipleSameAttribute.cs
@@ -1,0 +1,9 @@
+﻿using AutomaticTypeMapper;
+
+namespace WorkingAssembly
+{
+    public interface UsedAcrossAssemblies { }
+
+    [AutoMappedType]
+    public class UsedAcrossAssembliesImpl1 : UsedAcrossAssemblies { }
+}

--- a/WorkingAssembly/Properties/AssemblyInfo.cs
+++ b/WorkingAssembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WorkingAssembly")]
+[assembly: AssemblyDescription("Valid types in a separate assembly for use in AutomaticTypeMapper.Test")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WorkingAssembly")]
+[assembly: AssemblyCopyright("Copyright © Ethan Moffat 2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("41d2e11e-35b4-42a0-b661-dcc74369b86d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WorkingAssembly/WorkingAssembly.csproj
+++ b/WorkingAssembly/WorkingAssembly.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4F519896-6520-493F-AD14-B0C898FD696B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WorkingAssembly</RootNamespace>
+    <AssemblyName>WorkingAssembly</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\bin\test\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>..\bin\test\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MultipleSameAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AutomaticTypeMapper\AutomaticTypeMapper.csproj">
+      <Project>{02B42C8F-2128-4772-9107-EF3379CD0FAD}</Project>
+      <Name>AutomaticTypeMapper</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Fixes bug where varied registrations across assemblies wouldn't be registered properly